### PR TITLE
feat: add declarative resource state transition hooks

### DIFF
--- a/src/hooks/dedup.js
+++ b/src/hooks/dedup.js
@@ -9,6 +9,7 @@ module.exports = function () { // eslint-disable-line no-unused-vars
         }
         const app = require('../app');
         const currentData = await app.service('resources').get(hook.id);
+        hook.params._currentData = currentData;
         const newData = _.merge({}, currentData, hook.data);
         // If the new data is equal to the current data (excluding _id), skip further processing
         if (equal(_.omit(newData, '_id'), _.omit(currentData, '_id'))) {

--- a/src/hooks/state-transitions.js
+++ b/src/hooks/state-transitions.js
@@ -1,0 +1,24 @@
+const transitions = [
+    {from: 4, to: 5, apply: (data, cur) => ({lastPosition: data.destination || cur.destination, destination: ''})},
+    {from: 2, to: 3, apply: (data, cur) => ({lastPosition: data.destination || cur.destination, destination: ''})},
+    {to: 1, apply: (data, cur) => cur.home ? {lastPosition: cur.home} : null},
+];
+
+module.exports = function (rules = transitions) {
+    return async function stateTransitions(hook) {
+        if (hook.result) return;
+        if (hook.data.state === undefined) return;
+
+        const current = hook.params._currentData
+            || await hook.app.service('resources').get(hook.id);
+
+        if (current.state === hook.data.state) return;
+
+        for (const rule of rules) {
+            if (rule.to !== hook.data.state) continue;
+            if (rule.from !== undefined && rule.from !== current.state) continue;
+            const changes = rule.apply(hook.data, current);
+            if (changes) Object.assign(hook.data, changes);
+        }
+    };
+};

--- a/src/services/resources/resources.hooks.js
+++ b/src/services/resources/resources.hooks.js
@@ -2,6 +2,7 @@ const {authenticate} = require('@feathersjs/authentication').hooks;
 const {isProvider, setNow, when} = require('feathers-hooks-common');
 const createLogEntry = require('../../hooks/create-log-entry')();
 const dedup = require('../../hooks/dedup')();
+const stateTransitions = require('../../hooks/state-transitions')();
 
 const updateSince = setNow('since');
 
@@ -11,8 +12,8 @@ module.exports = {
     find: [],
     get: [],
     create: [],
-    update: [updateSince],
-    patch: [dedup, updateSince],
+    update: [stateTransitions, updateSince],
+    patch: [dedup, stateTransitions, updateSince],
     remove: []
   },
 

--- a/test/hooks/state-transitions.test.js
+++ b/test/hooks/state-transitions.test.js
@@ -1,0 +1,78 @@
+import { describe, it, beforeAll, afterEach } from 'vitest';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const app = require('../../src/app');
+
+describe('state-transitions hook', () => {
+    const service = app.service('resources');
+    const created = [];
+
+    beforeAll(async () => {
+        const mongoose = app.get('mongooseClient');
+        if (mongoose.connection.readyState === 0) {
+            await mongoose.connect(process.env.MONGODB_URI || app.get('mongodb'));
+        }
+    });
+
+    async function createResource(data) {
+        const resource = await service.create({callSign: `TEST-${Date.now()}`, type: 'RTW', ...data});
+        created.push(resource._id);
+        return resource;
+    }
+
+    afterEach(async () => {
+        for (const id of created) {
+            try { await service.remove(id); } catch { /* already removed */ }
+        }
+        created.length = 0;
+    });
+
+    it('4→5: copies destination to lastPosition and clears destination', async () => {
+        const resource = await createResource({state: 4, destination: 'Hospital A'});
+        const patched = await service.patch(resource._id, {state: 5});
+        assert.equal(patched.lastPosition, 'Hospital A');
+        assert.equal(patched.destination, '');
+    });
+
+    it('2→3: copies destination to lastPosition and clears destination', async () => {
+        const resource = await createResource({state: 2, destination: 'Scene B'});
+        const patched = await service.patch(resource._id, {state: 3});
+        assert.equal(patched.lastPosition, 'Scene B');
+        assert.equal(patched.destination, '');
+    });
+
+    it('any→1 with home: sets lastPosition to home', async () => {
+        const resource = await createResource({state: 3, home: 'Station Alpha'});
+        const patched = await service.patch(resource._id, {state: 1});
+        assert.equal(patched.lastPosition, 'Station Alpha');
+    });
+
+    it('any→1 without home: does not change lastPosition', async () => {
+        const resource = await createResource({state: 3, lastPosition: 'Existing'});
+        const patched = await service.patch(resource._id, {state: 1});
+        assert.equal(patched.lastPosition, 'Existing');
+    });
+
+    it('non-matching transition: no side effects', async () => {
+        const resource = await createResource({state: 1, destination: 'Somewhere', lastPosition: 'Here'});
+        const patched = await service.patch(resource._id, {state: 2});
+        assert.equal(patched.destination, 'Somewhere');
+        assert.equal(patched.lastPosition, 'Here');
+    });
+
+    it('same state (dedup): no side effects', async () => {
+        const resource = await createResource({state: 4, destination: 'Hospital', lastPosition: 'Old'});
+        const patched = await service.patch(resource._id, {state: 4});
+        assert.equal(patched.destination, 'Hospital');
+        assert.equal(patched.lastPosition, 'Old');
+    });
+
+    it('4→5 with destination in patch data: uses patch destination', async () => {
+        const resource = await createResource({state: 4, destination: 'Old Hospital'});
+        const patched = await service.patch(resource._id, {state: 5, destination: 'New Hospital'});
+        assert.equal(patched.lastPosition, 'New Hospital');
+        assert.equal(patched.destination, '');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds a declarative before-hook that applies side effects on resource state changes:
  - **4→5**: `destination` → `lastPosition`, `destination` cleared
  - **2→3**: `destination` → `lastPosition`, `destination` cleared
  - **any→1**: `lastPosition` set to `home` (if configured)
- Transition rules are defined as a simple array, making it easy to add new state-driven behaviors
- Dedup hook now shares fetched data via `hook.params._currentData` to avoid redundant DB reads

## Test plan
- [x] 7 integration tests covering all transition rules and edge cases
- [x] Manual test: patch a resource's state via REST API and verify field changes
- [ ] Run e2e tests to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)