### PR TITLE
fix: moment German locale broken since Vite migration

### DIFF
--- a/e2e/tests/locale.spec.js
+++ b/e2e/tests/locale.spec.js
@@ -1,0 +1,41 @@
+const { test, expect } = require('@playwright/test');
+const { ApiHelper } = require('../helpers/api');
+
+test.describe('German locale formatting', () => {
+  let api;
+
+  test.beforeEach(async () => {
+    api = new ApiHelper();
+    await api.authenticate();
+  });
+
+  test.afterEach(async () => {
+    await api.cleanup();
+  });
+
+  test('log page displays dates in German format (DD.MM.YYYY HH:mm)', async ({ page }) => {
+    const resource = await api.createResource({
+      callSign: 'LOCALE-E2E',
+      type: 'RTW',
+      tetra: '66099',
+      state: 0,
+    });
+
+    await api.patchResource(resource._id, { state: 1 });
+
+    await page.goto('/log');
+
+    const row = page.locator('tr', { hasText: 'LOCALE-E2E' }).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+
+    const timestampCell = row.locator('td').first();
+    const timestampText = await timestampCell.textContent();
+
+    // German 'L LT' format: DD.MM.YYYY HH:mm (e.g., 13.04.2026 14:30)
+    // English 'L LT' format: MM/DD/YYYY h:mm AM/PM
+    expect(timestampText).toMatch(/\d{2}\.\d{2}\.\d{4} \d{2}:\d{2}/);
+    expect(timestampText).not.toContain('/');
+    expect(timestampText).not.toContain('AM');
+    expect(timestampText).not.toContain('PM');
+  });
+});

--- a/web/components/JournalEditor.jsx
+++ b/web/components/JournalEditor.jsx
@@ -5,7 +5,7 @@ import {Select, TextInput} from "./formControls";
 import {inject, observer} from "mobx-react";
 import {selectOptions} from "~/stores/journal";
 import authenticate from "./authenticate";
-import moment from "moment";
+import moment from "~/moment";
 import restrictToRoles from "~/components/restrictToRoles";
 
 const SelectWithOptions = ({field, options}) =>

--- a/web/components/JournalList.jsx
+++ b/web/components/JournalList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {inject, observer} from "mobx-react";
-import moment from "moment";
+import moment from "~/moment";
 import "../styles/resourceList.css";
 import {SortToggle} from "./SortToggle";
 import "../styles/journalList.css";

--- a/web/components/LogList.jsx
+++ b/web/components/LogList.jsx
@@ -1,7 +1,7 @@
 import {inject, observer} from "mobx-react";
 import React from "react";
 import states from "../shared/states";
-import moment from "moment";
+import moment from "~/moment";
 import {SortToggle} from "./SortToggle";
 import Card from "react-bootstrap/Card";
 

--- a/web/components/MessageList.jsx
+++ b/web/components/MessageList.jsx
@@ -1,7 +1,7 @@
 import {inject, observer} from "mobx-react";
 import React from "react";
 import states from "../shared/states";
-import moment from "moment";
+import moment from "~/moment";
 import restrictToRoles from "~/components/restrictToRoles";
 import Card from "react-bootstrap/Card";
 

--- a/web/components/ResourceList.jsx
+++ b/web/components/ResourceList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {inject, observer} from "mobx-react";
-import moment from "moment";
+import moment from "~/moment";
 import states from "../shared/states";
 import "../styles/resourceList.css";
 import {OverlayTrigger, Popover, Tooltip} from "react-bootstrap";

--- a/web/components/TodoDropdown.jsx
+++ b/web/components/TodoDropdown.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {inject, observer} from 'mobx-react';
 import {NavDropdown} from 'react-bootstrap';
 import restrictToRoles from "~/components/restrictToRoles";
-import moment from "moment";
+import moment from "~/moment";
 
 export const TodoDropdown = restrictToRoles(['dispo'])(inject('todos')(observer(({todos}) =>
     <NavDropdown id="todos" title={<span><i className="fa fa-list"/> Todos</span>}>

--- a/web/containers/map.jsx
+++ b/web/containers/map.jsx
@@ -28,7 +28,7 @@ import {fromExtent} from "ol/geom/Polygon";
 import {register} from "ol/proj/proj4";
 import proj4 from "proj4";
 import ResourceEditor from "~/components/ResourceEditor";
-import moment from "moment";
+import moment from "~/moment";
 import umfeld from "~/pois/umfeld.json";
 
 proj4.defs('EPSG:32633', '+proj=utm +zone=33 +datum=WGS84 +units=m +no_defs');

--- a/web/containers/overview.jsx
+++ b/web/containers/overview.jsx
@@ -5,7 +5,7 @@ import {CardBody, CardHeader, CardTitle, Col, Row} from "react-bootstrap";
 import {inject, observer} from "mobx-react";
 import authenticate from "../components/authenticate";
 import StationLoad from "~/components/StationLoad";
-import moment from "moment";
+import moment from "~/moment";
 import Card from "react-bootstrap/Card";
 
 export default authenticate(inject('auth', 'stations')(observer(({auth, stations}) =>

--- a/web/containers/transports.jsx
+++ b/web/containers/transports.jsx
@@ -1,7 +1,7 @@
 import authenticate from "~/components/authenticate";
 import {inject, observer} from "mobx-react";
 import React from "react";
-import moment from "moment";
+import moment from "~/moment";
 import {Button, CardBody, FormGroup} from "react-bootstrap";
 import {priorities, states, types} from "~/shared/strings";
 import ExportButton from "~/components/ExportButton";

--- a/web/forms/todoForm.js
+++ b/web/forms/todoForm.js
@@ -1,7 +1,7 @@
 import {BaseForm} from "~/forms/baseForm";
 import {action, makeObservable, observable} from 'mobx';
 import _ from 'lodash';
-import moment from "moment";
+import moment from "~/moment";
 import {todos} from "~/app";
 import {notification} from "~/stores";
 

--- a/web/forms/validators.js
+++ b/web/forms/validators.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from "~/moment";
 
 export function minLength(length) {
     return ({field}) => {

--- a/web/index.jsx
+++ b/web/index.jsx
@@ -1,7 +1,7 @@
+import "~/moment";
 import React from "react";
 import {createRoot} from "react-dom/client";
 import Container from "./Container.jsx";
-import moment from "moment";
 import 'bootstrap/dist/css/bootstrap.min.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import "./styles/global.css";
@@ -15,5 +15,4 @@ function renderApp(AppComponent) {
     );
 }
 
-moment.locale('de');
 renderApp(Container);

--- a/web/moment.js
+++ b/web/moment.js
@@ -1,0 +1,76 @@
+import moment from 'moment';
+
+// Register the German locale directly instead of importing 'moment/locale/de'.
+// The CJS locale file uses require('../moment') internally, which resolves to a
+// different moment instance when Vite/Rollup splits moment into a vendor chunk.
+function processRelativeTime(number, withoutSuffix, key) {
+  var format = {
+    m: ['eine Minute', 'einer Minute'],
+    h: ['eine Stunde', 'einer Stunde'],
+    d: ['ein Tag', 'einem Tag'],
+    dd: [number + ' Tage', number + ' Tagen'],
+    w: ['eine Woche', 'einer Woche'],
+    M: ['ein Monat', 'einem Monat'],
+    MM: [number + ' Monate', number + ' Monaten'],
+    y: ['ein Jahr', 'einem Jahr'],
+    yy: [number + ' Jahre', number + ' Jahren'],
+  };
+  return withoutSuffix ? format[key][0] : format[key][1];
+}
+
+moment.defineLocale('de', {
+  months:
+    'Januar_Februar_März_April_Mai_Juni_Juli_August_September_Oktober_November_Dezember'.split(
+      '_'
+    ),
+  monthsShort:
+    'Jan._Feb._März_Apr._Mai_Juni_Juli_Aug._Sep._Okt._Nov._Dez.'.split('_'),
+  monthsParseExact: true,
+  weekdays:
+    'Sonntag_Montag_Dienstag_Mittwoch_Donnerstag_Freitag_Samstag'.split('_'),
+  weekdaysShort: 'So._Mo._Di._Mi._Do._Fr._Sa.'.split('_'),
+  weekdaysMin: 'So_Mo_Di_Mi_Do_Fr_Sa'.split('_'),
+  weekdaysParseExact: true,
+  longDateFormat: {
+    LT: 'HH:mm',
+    LTS: 'HH:mm:ss',
+    L: 'DD.MM.YYYY',
+    LL: 'D. MMMM YYYY',
+    LLL: 'D. MMMM YYYY HH:mm',
+    LLLL: 'dddd, D. MMMM YYYY HH:mm',
+  },
+  calendar: {
+    sameDay: '[heute um] LT [Uhr]',
+    sameElse: 'L',
+    nextDay: '[morgen um] LT [Uhr]',
+    nextWeek: 'dddd [um] LT [Uhr]',
+    lastDay: '[gestern um] LT [Uhr]',
+    lastWeek: '[letzten] dddd [um] LT [Uhr]',
+  },
+  relativeTime: {
+    future: 'in %s',
+    past: 'vor %s',
+    s: 'ein paar Sekunden',
+    ss: '%d Sekunden',
+    m: processRelativeTime,
+    mm: '%d Minuten',
+    h: processRelativeTime,
+    hh: '%d Stunden',
+    d: processRelativeTime,
+    dd: processRelativeTime,
+    w: processRelativeTime,
+    ww: '%d Wochen',
+    M: processRelativeTime,
+    MM: processRelativeTime,
+    y: processRelativeTime,
+    yy: processRelativeTime,
+  },
+  dayOfMonthOrdinalParse: /\d{1,2}\./,
+  ordinal: '%d.',
+  week: {
+    dow: 1, // Monday is the first day of the week.
+    doy: 4, // The week that contains Jan 4th is the first week of the year.
+  },
+});
+
+export default moment;

--- a/web/stores/calls.js
+++ b/web/stores/calls.js
@@ -3,7 +3,7 @@ import {resourceAdmin, talkGroups} from '~/stores';
 import {loginReaction} from "~/stores/index";
 import {action, computed, makeObservable, observable} from "mobx";
 import _ from "lodash";
-import moment from "moment";
+import moment from "~/moment";
 
 export class CallStore {
     list = [];

--- a/web/stores/journal.js
+++ b/web/stores/journal.js
@@ -3,7 +3,7 @@ import {journal} from '~/app';
 import {Form} from 'mobx-react-form';
 import _ from 'lodash';
 import {loginReaction, notification} from '../stores';
-import moment from 'moment';
+import moment from '~/moment';
 import validator from "validator";
 import {date, required} from "~/forms/validators";
 

--- a/web/stores/todos.js
+++ b/web/stores/todos.js
@@ -4,7 +4,7 @@ import {TodoForm} from "~/forms/todoForm";
 import {loginReaction} from "~/stores/index";
 import {todos} from "~/app";
 import _ from "lodash";
-import moment from "moment";
+import moment from "~/moment";
 
 export class TodoStore {
     list = [];


### PR DESCRIPTION
## Summary

- `moment.locale('de')` silently failed after the webpack-to-Vite migration because Vite only bundles explicitly imported code (webpack bundled all moment locales by default)
- The standard `import 'moment/locale/de'` side-effect import also doesn't work because its internal CJS `require('../moment')` resolves to a different moment instance when Rollup splits moment into a vendor chunk
- Fix: inline the German locale config via `moment.defineLocale()` in a centralized wrapper (`web/moment.js`) and route all imports through `~/moment`

## Test plan

- [x] New e2e test `e2e/tests/locale.spec.js` verifies log page timestamps use German format (`DD.MM.YYYY HH:mm`) instead of English (`MM/DD/YYYY h:mm AM/PM`)
- [x] Verify date formatting in dev mode (`npm run web:dev`)