### PR TITLE
feat: add TETRA source attribution to resource state changes

### DIFF
--- a/e2e/tests/stations.spec.js
+++ b/e2e/tests/stations.spec.js
@@ -54,9 +54,14 @@ test.describe('Stations', () => {
 
   test('new station card is highlighted before saving', async ({ page }) => {
     await page.goto('/stations');
-    await expect(page.getByRole('button', { name: 'hinzufügen' })).toBeVisible({ timeout: 10_000 });
+    const addButton = page.getByRole('button', { name: 'hinzufügen' });
+    await expect(addButton).toBeVisible({ timeout: 10_000 });
 
-    await page.getByRole('button', { name: 'hinzufügen' }).click({ force: true });
+    // Wait for the stations list to finish loading before clicking,
+    // otherwise find() can overwrite the locally added station.
+    await page.waitForLoadState('networkidle');
+
+    await addButton.click();
 
     const newCard = page.locator('.card', { hasText: 'Neue SanHiSt' });
     await expect(newCard).toBeVisible({ timeout: 10_000 });

--- a/e2e/tests/status-changes.spec.js
+++ b/e2e/tests/status-changes.spec.js
@@ -66,4 +66,57 @@ test.describe('LARDIS Status Simulation', () => {
     // Should update via Socket.IO
     await expect(row.locator('td', { hasText: 'zum Berufungsort' })).toBeVisible({ timeout: 10_000 });
   });
+
+  test('TETRA source shows tower icon in overview', async ({ page }) => {
+    const resource = await api.createResource({
+      callSign: 'TETRA-1',
+      type: 'RTW',
+      tetra: '88004',
+      state: 0,
+    });
+
+    await page.goto('/');
+    await expect(page.locator('td', { hasText: 'TETRA-1' })).toBeVisible({ timeout: 10_000 });
+
+    // Simulate LARDIS status change with source: 'tetra'
+    await api.patchResource(resource._id, { state: 1, source: 'tetra' });
+
+    const row = page.locator('tr', { hasText: 'TETRA-1' });
+    await expect(row.locator('.fa-tower-broadcast')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('TETRA source shows "TETRA" in log', async ({ page }) => {
+    const resource = await api.createResource({
+      callSign: 'TETRA-2',
+      type: 'RTW',
+      tetra: '88005',
+      state: 0,
+    });
+
+    await api.patchResource(resource._id, { state: 1, source: 'tetra' });
+
+    await page.goto('/log');
+    const row = page.locator('tr', { hasText: 'TETRA-2' }).first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.locator('td', { hasText: 'TETRA' }).last()).toBeVisible();
+  });
+
+  test('manual state change shows no TETRA indicator', async ({ page }) => {
+    const resource = await api.createResource({
+      callSign: 'MANUAL-1',
+      type: 'RTW',
+      tetra: '88006',
+      state: 0,
+    });
+
+    await page.goto('/');
+    await expect(page.locator('td', { hasText: 'MANUAL-1' })).toBeVisible({ timeout: 10_000 });
+
+    // State change without source (manual/UI change)
+    await api.patchResource(resource._id, { state: 1 });
+
+    const row = page.locator('tr', { hasText: 'MANUAL-1' });
+    await expect(row.locator('td', { hasText: 'Einsatzbereit' })).toBeVisible({ timeout: 10_000 });
+    await expect(row.locator('.fa-tower-broadcast')).not.toBeVisible();
+  });
 });

--- a/src/hooks/create-log-entry.js
+++ b/src/hooks/create-log-entry.js
@@ -18,6 +18,7 @@ module.exports = function (options = {}) { // eslint-disable-line no-unused-vars
         const entry = _.omit(hook.result, '_id');
         entry.resource_id = resourceId;
         entry.user_id = _.get(hook, 'params.user._id');
+        entry.source = hook.params.source;
         entry.since = new Date();
         return hook.app.service('log').create(entry).then(() => hook);
     };

--- a/src/lardis.js
+++ b/src/lardis.js
@@ -69,7 +69,7 @@ module.exports = function () {
             radio.connection.write(command, 'utf8', () => {
                 messages.patch(m._id, {state: 'sent'});
             });
-            resources.patch(null, {state: 10}, {query: {tetra: destination}}).then(([resource]) => {
+            resources.patch(null, {state: 10}, {query: {tetra: destination}, source: 'tetra'}).then(([resource]) => {
                 if (callOutCC && callOutCC.length > 0) {
                     callOutCC.forEach(issi => {
                         messages.create({
@@ -188,7 +188,7 @@ module.exports = function () {
     function setResourceState(issi, state) {
         resources.find({query: {tetra: issi}}).then(result => {
             if (result.length === 1) {
-                resources.patch(result[0]._id, {state})
+                resources.patch(result[0]._id, {state}, {source: 'tetra'})
                     .catch(error => logger.error(`Failed to update resource state for ISSI ${issi}:`, error));
             }
         }).catch(error => {

--- a/src/models/log.model.js
+++ b/src/models/log.model.js
@@ -17,7 +17,8 @@ const schema = new mongoose.Schema({
         username: String,
         name: String,
         initials: String
-    }
+    },
+    source: String
 });
 
 module.exports = function (app) {

--- a/src/models/resources.model.js
+++ b/src/models/resources.model.js
@@ -8,6 +8,7 @@ const schema = new mongoose.Schema({
     vehicle: String,
     state: Number,
     since: {type: Date, default: Date.now},
+    source: String,
     lastPosition: String,
     destination: String,
     contact: String,

--- a/src/services/resources/resources.hooks.js
+++ b/src/services/resources/resources.hooks.js
@@ -9,6 +9,7 @@ const updateSince = async (hook) => {
     const current = hook.params._currentData || (hook.id && await hook.app.service('resources').get(hook.id));
     if (!current || hook.data.state !== current.state) {
       hook.data.since = new Date();
+      hook.data.source = hook.params.source || hook.data.source || null;
     }
   }
 };

--- a/web/components/LogList.jsx
+++ b/web/components/LogList.jsx
@@ -36,7 +36,7 @@ export default inject('log')(observer(({log}) =>
                     <td>{r.contact}</td>
                     <td>{r.info}</td>
                     <td>{r.hidden && <i className="fa fa-eye-slash"/>}</td>
-                    <td>{r.user && r.user.initials}</td>
+                    <td>{r.source === 'tetra' ? 'TETRA' : r.user && r.user.initials}</td>
                 </tr>)}
             </tbody>
         </table>

--- a/web/components/ResourceList.jsx
+++ b/web/components/ResourceList.jsx
@@ -47,7 +47,7 @@ export default inject('auth', 'resources', 'transports', 'calls')(observer(({aut
                     <td>{r.type}</td>
                     <td>{r.callSign}</td>
                     <td>{states.get(r.state).name}</td>
-                    <td>{r.since && moment(r.since).format('LT')}</td>
+                    <td>{r.since && moment(r.since).format('LT')}{r.source === 'tetra' && <i className="fa-solid fa-tower-broadcast ms-2" title="TETRA"/>}</td>
                     <td>{r.lastPosition}</td>
                     <td>{r.destination}</td>
                     <td>{r.info}</td>


### PR DESCRIPTION
## Summary
- Track the origin of resource state changes by adding a `source` field to both the resource and log models
- When lardis updates state via TETRA, `source: 'tetra'` is recorded on the resource and log entry
- Overview page shows a tower broadcast icon next to the timestamp for TETRA-triggered changes
- Log page shows "TETRA" in the Benutzer column instead of user initials

## Test plan
- [x] Unit tests pass (`npm test`, 35/35)
- [x] E2e tests: 3 new tests in `status-changes.spec.js` covering TETRA icon in overview, "TETRA" text in log, and absence of indicator for manual changes
- [x] Manual: use curl with `source: 'tetra'` in patch body to verify icon and log text